### PR TITLE
Fix clippy warnings and introduce config struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,12 @@ twocaptcha = "0.0.1"
 ## Example
 
 ```rust,no_run
-use twocaptcha::{TwoCaptcha, RecaptchaVersion};
+use twocaptcha::{TwoCaptcha, TwoCaptchaConfig, RecaptchaVersion};
 use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let solver = TwoCaptcha::new(
-        "YOUR_API_KEY".to_string(),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    );
+    let solver = TwoCaptcha::new("YOUR_API_KEY".to_string(), TwoCaptchaConfig::default());
 
     let mut params = HashMap::new();
     params.insert("min_score".to_string(), "0.3".to_string());

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use twocaptcha::{RecaptchaVersion, TwoCaptcha};
+use twocaptcha::{RecaptchaVersion, TwoCaptcha, TwoCaptchaConfig};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -7,15 +7,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key =
         std::env::var("TWOCAPTCHA_API_KEY").unwrap_or_else(|_| "YOUR_API_KEY".to_string());
 
-    let solver = TwoCaptcha::new(
-        api_key, None, // soft_id
-        None, // callback
-        None, // default_timeout
-        None, // recaptcha_timeout
-        None, // polling_interval
-        None, // server
-        None, // extended_response
-    );
+    let solver = TwoCaptcha::new(api_key, TwoCaptchaConfig::default());
 
     println!("2captcha Rust Library Example");
     println!("==============================");

--- a/src/api.rs
+++ b/src/api.rs
@@ -48,9 +48,7 @@ impl ApiClient {
             let mut form_params = params.clone();
             form_params.remove("file");
 
-            let file_content = tokio::fs::read(&file_path)
-                .await
-                .map_err(|e| TwoCaptchaError::Io(e))?;
+            let file_content = tokio::fs::read(&file_path).await?;
 
             let mut form = Form::new();
             for (key, value) in form_params {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,21 +7,12 @@
 //! ## Example
 //!
 //! ```no_run
-//! use twocaptcha::{TwoCaptcha, RecaptchaVersion};
+//! use twocaptcha::{TwoCaptcha, TwoCaptchaConfig, RecaptchaVersion};
 //! use std::collections::HashMap;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let solver = TwoCaptcha::new(
-//!         "your_api_key".to_string(),
-//!         None,  // soft_id
-//!         None,  // callback
-//!         None,  // default_timeout
-//!         None,  // recaptcha_timeout
-//!         None,  // polling_interval
-//!         None,  // server
-//!         None,  // extended_response
-//!     );
+//!     let solver = TwoCaptcha::new("your_api_key".to_string(), TwoCaptchaConfig::default());
 //!
 //!     // Solve a reCAPTCHA
 //!     let result = solver.recaptcha(
@@ -46,7 +37,7 @@ pub mod utils;
 // Re-export main types
 pub use api::ApiClient;
 pub use error::{Result, TwoCaptchaError};
-pub use solver::TwoCaptcha;
+pub use solver::{TwoCaptcha, TwoCaptchaConfig};
 pub use types::{AudioLanguage, Balance, CaptchaResult, ExtendedResponse, Proxy, RecaptchaVersion};
 
 // Re-export commonly used traits

--- a/src/types.rs
+++ b/src/types.rs
@@ -56,16 +56,20 @@ impl AudioLanguage {
             AudioLanguage::French => "fr",
         }
     }
+}
 
-    pub fn from_str(s: &str) -> Option<Self> {
+impl std::str::FromStr for AudioLanguage {
+    type Err = ();
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s {
-            "en" => Some(AudioLanguage::English),
-            "ru" => Some(AudioLanguage::Russian),
-            "de" => Some(AudioLanguage::German),
-            "el" => Some(AudioLanguage::Greek),
-            "pt" => Some(AudioLanguage::Portuguese),
-            "fr" => Some(AudioLanguage::French),
-            _ => None,
+            "en" => Ok(AudioLanguage::English),
+            "ru" => Ok(AudioLanguage::Russian),
+            "de" => Ok(AudioLanguage::German),
+            "el" => Ok(AudioLanguage::Greek),
+            "pt" => Ok(AudioLanguage::Portuguese),
+            "fr" => Ok(AudioLanguage::French),
+            _ => Err(()),
         }
     }
 }


### PR DESCRIPTION
## Summary
- introduce `TwoCaptchaConfig` to reduce arguments
- fix redundant closure and needless returns
- implement `FromStr` for `AudioLanguage`
- update docs and example for new API

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687b4b7de438832cbb7aa2b836f2bab7